### PR TITLE
Disallow posts by users who have blank profiles

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,6 +2,7 @@ class ArticlesController < ApplicationController
   before_filter :user_required,         :only => [:new, :create, :edit, :update, :destroy]
   before_filter :find_article,          :only => [:show, :edit, :update, :destroy]
   before_filter :authorized_users_only, :only => [:edit, :update, :destroy]
+  before_filter :profile_required,      :only => [:new, :create]
 
   def index
     @articles = Article.includes(:author).order("created_at desc").
@@ -59,5 +60,12 @@ class ArticlesController < ApplicationController
 
   def find_article
     @article = Article.find_by_slug(params[:id])
+  end
+
+  def profile_required
+    if current_user.description.blank?
+      flash[:error] = "Please add some information to your description and try again."
+      redirect_to edit_person_path(current_user)
+    end
   end
 end

--- a/test/integration/articles_test.rb
+++ b/test/integration/articles_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class ArticlesTest < ActionDispatch::IntegrationTest
+  test "articles can only be created by users with profiles" do
+    user = sign_user_in
+
+    visit new_article_path
+
+    assert_current_path edit_person_path(user)
+
+    assert_flash "Please add some information to your description and try again."
+
+    fill_in "Description", :with => "I love Mendicant University"
+
+    click_button "Save"
+
+    visit new_article_path
+
+    assert_current_path new_article_path
+  end
+end

--- a/test/support/auth.rb
+++ b/test/support/auth.rb
@@ -17,7 +17,11 @@ module Support
     def sign_user_in_with_mocks(user, hash)
       mock_auth_for(user)
       mock_uniweb_user(hash)
+
+      visit root_path
       click_link 'Sign in with Github'
+
+      user
     end
 
     def sign_user_in(user=Factory(:user))


### PR DESCRIPTION
As discussed in Issue #28, users will not be allowed to post updates until they have some content in their profile description.

Profiles equal :smile:

This implementation is very low touch and can easily be removed if / when we decide to remove it. 

Thoughts / comments always appreciated :heart:
