### PR TITLE
Warn users when leaving a page with unsubmitted changes on a form.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,6 +9,7 @@
 //= require md_preview
 //= require jquery.elastic
 //= require cocoon
+//= require save
 //= require_tree '../../../vendor/assets/javascripts'
 //= require_tree .
 

--- a/app/assets/javascripts/save.js
+++ b/app/assets/javascripts/save.js
@@ -1,0 +1,37 @@
+/*
+* save.js
+* Track changes in a form and display a warning if they haven't been submitted
+*
+* Usage:
+* Add 'data-track-changes=true' to any form which you want to track changes
+*
+*   <form data-track-changes=true> ... </form>
+*/
+
+Save = {
+  init: function(){
+
+    // Track keydown so changes are tracked immediately in
+    // textarea and input[type=text] elements, and change for select
+    jQuery('form[data-track-changes=true] :input').
+      keydown(Save.change).change(Save.change);
+
+    jQuery('form[data-track-changes=true]').submit(function(e){
+      jQuery('*[data-changed=true]').attr('data-changed', false);
+    });
+
+    jQuery(window).bind('beforeunload', Save.beforeUnload);
+  },
+  beforeUnload: function(){
+    if(Save.changesMade()) return "You have unsaved changes.";
+  },
+  changesMade: function(){
+    return (jQuery('*[data-changed=true]').length > 0)
+  },
+  change: function(){
+    jQuery(this).attr('data-changed', true);
+  }
+
+};
+
+jQuery(function() { Save.init(); });

--- a/app/views/activities/_form.html.haml
+++ b/app/views/activities/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @activity do |f|
+= form_for @activity, :html => { :data => { 'track-changes' => true } } do |f|
   = error_messages_for(@activity)
 
   .field

--- a/app/views/admin/pages/edit.html.haml
+++ b/app/views/admin/pages/edit.html.haml
@@ -1,6 +1,6 @@
 %h2 Edit Page
 
-= form_for @page, :url => admin_page_path(@page) do |f|
+= form_for @page, :url => admin_page_path(@page), :html => { :data => { 'track-changes' => true } } do |f|
   %p
     = f.label :title
     %br

--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @article, :html => { :id => "article-form" } do |f|
+= form_for @article, :html => { :id => "article-form", :data => { 'track-changes' => true } } do |f|
   = error_messages_for(@article)
 
   .field

--- a/app/views/people/edit.html.haml
+++ b/app/views/people/edit.html.haml
@@ -1,6 +1,6 @@
 %h1 Your Profile Information
 
-= form_for @person, :url => person_path(@person) do |f|
+= form_for @person, :url => person_path(@person), :html => { :data => { 'track-changes' => true } } do |f|
   = error_messages_for @person
 
   %p


### PR DESCRIPTION
See #34
