### PR TITLE
Articles can be restricted to members (fix #11)

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -12,6 +12,7 @@ class Article < ActiveRecord::Base
   end
 
   scope :newest, order("sticky desc, created_at desc")
+  scope :public_only, where(public_access: true)
 
   def to_param
     slug

--- a/app/views/articles/_form.html.haml
+++ b/app/views/articles/_form.html.haml
@@ -8,6 +8,9 @@
     //%span.hint Create a short and descriptive title for your post.
   .field
     = f.text_area :body, "data-preview" => true
+  .field
+    = f.check_box :public_access
+    = f.label :public_access
   - if current_user.admin?
     .field
       = f.check_box :sticky

--- a/db/migrate/20120217002323_alter_articles_add_public_access.rb
+++ b/db/migrate/20120217002323_alter_articles_add_public_access.rb
@@ -1,0 +1,9 @@
+class AlterArticlesAddPublicAccess < ActiveRecord::Migration
+  def up
+    add_column(:articles, :public_access, :boolean, default: true)
+  end
+
+  def down
+    remove_column(:articles, :public_access)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120215015127) do
+ActiveRecord::Schema.define(:version => 20120217002323) do
 
   create_table "activities", :force => true do |t|
     t.integer  "author_id"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(:version => 20120215015127) do
     t.string   "slug"
     t.boolean  "posted_to_twitter", :default => false, :null => false
     t.boolean  "sticky",            :default => false
+    t.boolean  "public_access",     :default => true
   end
 
   create_table "discussion_lists", :force => true do |t|

--- a/test/unit/article_test.rb
+++ b/test/unit/article_test.rb
@@ -52,4 +52,11 @@ class ArticleTest < ActiveSupport::TestCase
 
     assert_equal(["Article #1"], titles)
   end
+
+  test "list only public articles" do
+    FactoryGirl.create(:article, title: "Article #1", author: @user)
+    FactoryGirl.create(:article, title: "Article #2", author: @user, public_access: false)
+
+    assert_equal(1, Article.public_only.count)
+  end
 end


### PR DESCRIPTION
As discussed in #11, now articles can be restricted to MU members only.
Happy Mendicant University Global Hack Day :balloon:
