### PR TITLE
Add basic Atom feed

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -14,6 +14,7 @@ class ArticlesController < ApplicationController
 
     respond_with(@articles) do |format|
       format.rss { render :layout => false }
+      format.atom
     end
   end
 

--- a/app/views/articles/index.atom.builder
+++ b/app/views/articles/index.atom.builder
@@ -1,0 +1,17 @@
+atom_feed(url: articles_url(format: :atom)) do |feed|
+  feed.title    "Community @ Mendicant University"
+  feed.subtitle "Mendicant University's Community Site"
+  feed.updated  @articles.first.created_at
+
+  @articles.each do |article|
+    feed.entry(article) do |entry|
+      entry.title     article.title
+      entry.content   article.body, type: 'html'
+
+      entry.author do |author|
+        author.name   article.author.name
+        author.email  article.author.email
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here is a basic Atom feed. It's valid according to the W3C validator. I haven't linked it in `<head>` yet, but I think it's good enough for testing purposes, so we can move on with the [GitHub commit tracker](https://github.com/mendicant-university/mendibot/pull/31).

Let me know if something is missing.

ref. #73
