### PR TITLE
Sign In/Out should return user to the same location

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  helper_method :current_user, :signed_in?, :admin?
+  helper_method :current_user, :signed_in?, :admin?, :login_path
 
   before_filter :update_unread_count
 
@@ -25,7 +25,6 @@ class ApplicationController < ActionController::Base
 
   def user_required
     unless signed_in?
-      store_location
       redirect_to login_path
       return true
     end
@@ -37,7 +36,6 @@ class ApplicationController < ActionController::Base
         flash[:error] = "You must be an admin to access this area!"
         redirect_to root_path
       else
-        store_location
         redirect_to login_path
       end
     end
@@ -47,21 +45,11 @@ class ApplicationController < ActionController::Base
     [:new, :create, :edit, :update, :destroy]
   end
 
-  def store_location
-    session[:return_to] = request.fullpath
-  end
-
-  def access_denied
-    flash[:alert] = "Sorry, you can't access this area"
-    redirect_back_or_default root_path
-  end
-
-  def redirect_back_or_default(default)
-    redirect_to(session[:return_to] || default)
-    session[:return_to] = nil
-  end
-
   def update_unread_count
     @inbox = Inbox.new(current_user)
+  end
+
+  def login_path
+    Rails.env.development? ? '/auth/developer' : '/auth/github'
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,14 +1,6 @@
 class SessionsController < ApplicationController
   before_filter :check_permissions, :only => [:create]
 
-  def new
-    if Rails.env.development?
-      redirect_to '/auth/developer'
-    else
-      redirect_to '/auth/github'
-    end
-  end
-
   def create
     unless user = User.find_by_uid(auth_hash['uid'])
       user = User.create_from_hash(auth_hash, :name  => uniweb_user.name,
@@ -21,13 +13,13 @@ class SessionsController < ApplicationController
       self.current_user = user
     end
 
-    redirect_back_or_default root_path
+    redirect_to request.env['omniauth.origin'] || root_path
   end
 
   def destroy
     self.current_user = nil
 
-    redirect_to root_path
+    redirect_to request.env['HTTP_REFERER'] || root_path
   end
 
   def failure

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Community::Application.routes.draw do
 
   match '/auth/:provider/callback' => 'sessions#create'
   match '/auth/failure'            => 'sessions#failure'
-  match '/login'                   => 'sessions#new',     as: 'login'
   match '/logout'                  => 'sessions#destroy', as: 'logout'
 
   match '/read_all/:type' => 'people#read_all', as: 'read_all'


### PR DESCRIPTION
See #78:

I have fixed and refactored codes to use `request.env['omniauth.origin']`, so now after sign in users will stay on the page they are currently on.
